### PR TITLE
Fix transaction type logic for refunds

### DIFF
--- a/transaction-processed-table-config.json
+++ b/transaction-processed-table-config.json
@@ -70,7 +70,7 @@
       },
       {
         "columnName": "transaction_type",
-        "transformFunction": "CASE WHEN jsonPathString(data, '$.refundId') IS NOT NULL THEN 'REFUND' ELSE 'PAYMENT' END"
+        "transformFunction": "CASE WHEN jsonPathString(data, '$.refundId.id') IS NOT NULL THEN 'REFUND' ELSE 'PAYMENT' END"
       },
       {
         "columnName": "transaction_status",


### PR DESCRIPTION
Fix `transaction_type` logic to correctly classify refunds by checking `$.refundId.id`.

Previously, `transaction_type` checked for `$.refundId` existence, while `refund_id` extracted `$.refundId.id`. This inconsistency allowed transactions to be classified as 'REFUND' even when `refund_id` was null, violating the business rule that refunds must have a populated `refund_id`.